### PR TITLE
Show open panel by default

### DIFF
--- a/stream_overlays/__init__.py
+++ b/stream_overlays/__init__.py
@@ -43,7 +43,10 @@ class StreamOverlays:
             # Register a panel for each overlay on the streams page
             panel_id = f"stream_overlays_{overlay_name.lower()}"
             self._rhapi.ui.register_panel(
-                panel_id, f"{overlay_name} - OBS Overlays", "streams"
+                panel_id,
+                f"{overlay_name} - OBS Overlays",
+                "streams",
+                open=True,
             )
 
             # Create and register markdown blocks based on the features


### PR DESCRIPTION
SSIA

Depends on: https://github.com/RotorHazard/RotorHazard/pull/905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Panels now default to an open state upon creation, providing immediate visibility for new panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->