### PR TITLE
Fix some issues in the leaderboard overlays

### DIFF
--- a/stream_overlays/static/css/leaderboard/dds/class.css
+++ b/stream_overlays/static/css/leaderboard/dds/class.css
@@ -99,6 +99,13 @@
     border-radius: 15px 0 15px 0;
 }
 
+.leaderboard>p {
+    background: black;
+    color: white;
+    padding: 15px;
+    border-radius: 0 0 15px 15px;
+}
+
 /* Font styling for the entry */
 .box>p,
 .entry>p {

--- a/stream_overlays/static/css/leaderboard/dds/overall.css
+++ b/stream_overlays/static/css/leaderboard/dds/overall.css
@@ -2,6 +2,7 @@
 
 /* General styling */
 .container {
+    margin: 120px 120px 0 120px;
     width: 100%;
 }
 

--- a/stream_overlays/static/js/leaderboard/dds/class.js
+++ b/stream_overlays/static/js/leaderboard/dds/class.js
@@ -66,7 +66,7 @@ function showResultsData(data) {
                     if (currentClass.ranking) {
                         console.log('Ranking:', currentClass.ranking);
                     } else if ([currentClassLeaderboard].length) {
-                        generateLeaderboard(currentClassLeaderboard, displayType, 10, true);
+                        generateLeaderboard(currentClassLeaderboard, displayType, intervalTime=10);
                     } else {
                         showNoResults();
                     }
@@ -82,13 +82,13 @@ let currentGroupIndex = 0;
 const itemsPerPage = 8;
 let intervalID;
 
-function generateLeaderboard(data, displayType, intervalTime, loop = false) {
+function generateLeaderboard(data, displayType, intervalTime) {
     console.log('leaderboard:', data);
     const groupedData = chunkArray(data, itemsPerPage);
     updateHeaderLabels(displayType);
     displayGroup(data, groupedData, displayType, currentGroupIndex);
 
-    if (loop) {
+    if (data.length > itemsPerPage) {
         clearInterval(intervalID);
         intervalID = setInterval(() => {
             currentGroupIndex = (currentGroupIndex + 1) % groupedData.length;


### PR DESCRIPTION
- Add styling when there is no data
- Fix missing margin on the overall leaderboard overlay
- Remove the loop parameter on `generateLeaderboard`
- Auto loop when there is race data from more then 8 pilots