### PR TITLE
Add warning on creating overlays url's

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -22,6 +22,9 @@ sh -c "$(curl -fsSL https://short.dutchdronesquad.nl/install-overlays-plugin)"
 
 ## Stream displays
 
+!!! warning
+    Currently this only works with the dev branch of RotorHazard, it will be available in the next stable release (v4.2.x).
+
 After installing the plugin, you can find the overlays on the **Stream Displays** page in RotorHazard. The plugin will automatically create panels for each overlay, so you can easily find the URLs.
 
 ![alt stream displays](../assets/img/stream_overlays-page.png){ style="border-radius: 5px;" }

--- a/docs/overlays/index.md
+++ b/docs/overlays/index.md
@@ -15,5 +15,5 @@ Links to the specific theme overlays:
 !!! question "Ideas for new themes?"
     If you have ideas for a new overlay theme, you can always start a topic in the [discussions](https://github.com/dutchdronesquad/rh-stream-overlays/discussions) forum with some sketches or example images.
 
-!!! tip "Did you know?"
-    The stream overlays plugin also generates overlay URLs on the **Stream Displays** page in Rotorhazard, making it even easier to get the right URL for your overlay and use it in OBS 😉
+<!-- !!! tip "Did you know?"
+    The stream overlays plugin also generates overlay URLs on the **Stream Displays** page in Rotorhazard, making it even easier to get the right URL for your overlay and use it in OBS 😉 -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a warning in the installation guide for the RotorHazard overlays plugin, clarifying compatibility with the development branch.
	- Removed a tip section from the overlays documentation, altering the visibility of information regarding the stream overlays plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->